### PR TITLE
Use os.popen instead of tmp file

### DIFF
--- a/ASR/run_TIMIT_fast.py
+++ b/ASR/run_TIMIT_fast.py
@@ -26,9 +26,9 @@ import os
 
 def get_freer_gpu(trials=10):
     for j in range(trials):
-         f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
-         memory_available = [int(x.split()[2]) for x in f.readlines()]
-         dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
+        f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+        memory_available = [int(x.split()[2]) for x in f.readlines()]
+        dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
          try:
             a = torch.rand(1).cuda(dev_)
             return dev_

--- a/ASR/run_TIMIT_fast.py
+++ b/ASR/run_TIMIT_fast.py
@@ -26,8 +26,8 @@ import os
 
 def get_freer_gpu(trials=10):
     for j in range(trials):
-         os.system('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp')
-         memory_available = [int(x.split()[2]) for x in open('tmp', 'r').readlines()]
+         f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+         memory_available = [int(x.split()[2]) for x in f.readlines()]
          dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
          try:
             a = torch.rand(1).cuda(dev_)

--- a/emorec/run_IEMOCAP_fast.py
+++ b/emorec/run_IEMOCAP_fast.py
@@ -25,13 +25,13 @@ import os
 
 def get_freer_gpu(trials=10):
     for j in range(trials):
-         f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
-         memory_available = [int(x.split()[2]) for x in f.readlines()]
-         dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
-         try:
+        f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+        memory_available = [int(x.split()[2]) for x in f.readlines()]
+        dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
+        try:
             a = torch.rand(1).cuda(dev_)
             return dev_
-         except: 
+        except:
             pass
             print('NO GPU AVAILABLE!!!')
             exit(1)

--- a/emorec/run_IEMOCAP_fast.py
+++ b/emorec/run_IEMOCAP_fast.py
@@ -25,8 +25,8 @@ import os
 
 def get_freer_gpu(trials=10):
     for j in range(trials):
-         os.system('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp')
-         memory_available = [int(x.split()[2]) for x in open('tmp', 'r').readlines()]
+         f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+         memory_available = [int(x.split()[2]) for x in f.readlines()]
          dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
          try:
             a = torch.rand(1).cuda(dev_)

--- a/spk_id/run_minivox_fast.py
+++ b/spk_id/run_minivox_fast.py
@@ -24,18 +24,18 @@ from pase.models.frontend import wf_builder
 import soundfile as sf
 
 def get_freer_gpu(trials=10):
-	for j in range(trials):
-		f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
-		memory_available = [int(x.split()[2]) for x in f.readlines()]
-		dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
-		try:
-			a = torch.rand(1).cuda(dev_)
-			return dev_
-		except:
-			pass
+    for j in range(trials):
+        f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+        memory_available = [int(x.split()[2]) for x in f.readlines()]
+        dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
+        try:
+            a = torch.rand(1).cuda(dev_)
+            return dev_
+        except:
+            pass
 
-	print('NO GPU AVAILABLE!!!')
-	exit(1)
+    print('NO GPU AVAILABLE!!!')
+    exit(1)
 
 def get_nspk(utt2spk):
     lab_list = []

--- a/spk_id/run_minivox_fast.py
+++ b/spk_id/run_minivox_fast.py
@@ -25,8 +25,8 @@ import soundfile as sf
 
 def get_freer_gpu(trials=10):
 	for j in range(trials):
-		os.system('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp')
-		memory_available = [int(x.split()[2]) for x in open('tmp', 'r').readlines()]
+		f = os.popen('nvidia-smi -q -d Memory |grep -A4 GPU|grep Free')
+		memory_available = [int(x.split()[2]) for x in f.readlines()]
 		dev_ = torch.device('cuda:'+str(np.argmax(memory_available)))
 		try:
 			a = torch.rand(1).cuda(dev_)


### PR DESCRIPTION
1. use os.popen
    - In this way, tmp file is not required
2. fix over-indented and tab indent
    - I only fixed where os.popen is used