### PR TITLE
PyCode2 / how to get it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the official implementations of [PASE](https://arxiv.or
 
 * PyTorch 1.0 or higher
 * Torchvision 0.2 or higher
+* To use data augmentation during training (recommended), you must [build codec2 **from source**](https://github.com/drowe67/codec2), then `pip install pycodec2` (because `pycodec2` needs the header files).  You may also need to point `LD_LIBRARY_PATH` at `\usr\local\lib` for python to be able to load `pycodec2` successfully.
 * Install the requirements from `requirements.txt`: `pip install -r requirements.txt`
 
 *NOTE: Edit the cupy-cuda100 requirement in the file if needed depending on your CUDA version. Defaults to 10.0 now*


### PR DESCRIPTION
I found the data augmentation code had a dependency on pycodec2, which doesn't seem to be covered in the original documentation or requirements file.  You can't just `pip install pycodec2` either, because of its dependency on codec2, so I think it's worth adding a little detail to the readme?  The data augmentation is so useful, it would be a shame if people were discouraged from training with it.