### PR TITLE
Better advice for pycodec2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git make cmake python3-pip
+RUN git clone https://github.com/drowe67/codec2.git
+RUN cd codec2 && \
+    mkdir build_linux && \
+    cd build_linux && \
+    cmake .. && \
+    make && \
+    make install
+RUN pip3 install cython numpy
+RUN git clone https://github.com/edwarddixon/pycodec2 && \
+    cd pycodec2 && \
+    python3 setup.py install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the official implementations of [PASE](https://arxiv.or
 
 * PyTorch 1.0 or higher
 * Torchvision 0.2 or higher
-* To use data augmentation during training (recommended), you must [build codec2 **from source**](https://github.com/drowe67/codec2), then `pip install pycodec2` (because `pycodec2` needs the header files).  You may also need to point `LD_LIBRARY_PATH` at `\usr\local\lib` for python to be able to load `pycodec2` successfully.
+* To use data augmentation during training (recommended), you must [build codec2 **from source**](https://github.com/drowe67/codec2), then [build its python wrapper, `pycodec`, also from source](https://github.com/EdwardDixon/pycodec2) (easy and painless).  You may also need to point `LD_LIBRARY_PATH` at `\usr\local\lib` for python to be able to load `pycodec2` successfully.
 * Install the requirements from `requirements.txt`: `pip install -r requirements.txt`
 
 *NOTE: Edit the cupy-cuda100 requirement in the file if needed depending on your CUDA version. Defaults to 10.0 now*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the official implementations of [PASE](https://arxiv.or
 
 * PyTorch 1.0 or higher
 * Torchvision 0.2 or higher
+* To use data augmentation during training (recommended), you must [build codec2 **from source**](https://github.com/drowe67/codec2), then `pip install pycodec2` (because `pycodec2` needs the header files).  You may also need to point `LD_LIBRARY_PATH` at `\usr\local\lib` for python to be able to load `pycodec2` successfully.
 * Install the requirements from `requirements.txt`: `pip install -r requirements.txt`
 
 *NOTE: Edit the cupy-cuda100 requirement in the file if needed depending on your CUDA version. Defaults to 10.0 now*

--- a/cfg/frontend/PASE+_gru.cfg
+++ b/cfg/frontend/PASE+_gru.cfg
@@ -1,0 +1,11 @@
+{
+ "kwidths":[251, 20, 11, 11, 11, 11, 11, 11],
+ "strides":[1, 10, 2, 1, 2, 1, 2, 2],
+ "fmaps":[64, 64, 128, 128, 256, 256, 512, 512],
+ "rnn_dim":512,
+ "denseskips":true,
+ "norm_out":true,
+ "rnn_pool":true,
+ "rnn_layers":1,
+ "rnn_type":"GRU"
+}

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+ENV http_proxy="http://proxy-us.intel.com:911" \
+    https_proxy="http://proxy-us.intel.com:912"
+COPY apt.conf /etc/apt/apt.conf
+RUN apt-get update && \
+    apt-get install -y python && \
+    apt-get install -y git make cmake python3-pip sox libsox-dev libsox-fmt-all
+RUN git config --global http.proxy http://proxy-us.intel.com:911 && \
+    git config --global https.proxy http://proxy-us.intel.com:912 && \
+    git clone https://github.com/drowe67/codec2.git
+RUN cd codec2 && \
+    mkdir build_linux && \
+    cd build_linux && \
+    cmake .. && \
+    make && \
+    make install 
+COPY requirements.txt /home
+RUN pip3 install cython numpy && \
+    pip3 install git+https://github.com/gregorias/pycodec2.git --global-option=build_ext --global-option="-I/usr/local/include/" --global-option="-L/usr/local/lib"  && \
+    pip3 install -r /home/requirements.txt
+

--- a/dockerfile_intel
+++ b/dockerfile_intel
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+ENV http_proxy="http://proxy-us.intel.com:911" \
+    https_proxy="http://proxy-us.intel.com:912"
+COPY apt.conf /etc/apt/apt.conf
+RUN apt-get update && \
+    apt-get install -y python && \
+    apt-get install -y git make cmake python3-pip sox libsox-dev libsox-fmt-all
+RUN git config --global http.proxy http://proxy-us.intel.com:911 && \
+    git config --global https.proxy http://proxy-us.intel.com:912 && \
+    git clone https://github.com/drowe67/codec2.git
+RUN cd codec2 && \
+    mkdir build_linux && \
+    cd build_linux && \
+    cmake .. && \
+    make && \
+    make install 
+COPY requirements.txt /home
+RUN pip3 install cython numpy && \
+    pip3 install git+https://github.com/gregorias/pycodec2.git --global-option=build_ext --global-option="-I/usr/local/include/" --global-option="-L/usr/local/lib"  && \
+    pip3 install -r /home/requirements.txt
+

--- a/pase/models/WorkerScheduler/trainer.py
+++ b/pase/models/WorkerScheduler/trainer.py
@@ -390,6 +390,11 @@ class trainer(object):
         pbar.write("=" * 50)
         pbar.write('Batch {}/{} (Epoch {}) step: {}:'.format(bidx, self.bpe, epoch, step))
 
+        neptune.log_text('Batch {}/{} (Epoch {}) step: {}:'.format(bidx, self.bpe, epoch, step))
+
+        for lr in lrs.keys():
+            neptune.log_metric(f"learning_rate_{lr}", lrs[lr])
+
         for name, loss in losses.items():
             if name == "total":
                 pbar.write('%s, learning rate = %.8f, loss = %.4f' % ("total", lrs['frontend'], loss))

--- a/pase/models/WorkerScheduler/trainer.py
+++ b/pase/models/WorkerScheduler/trainer.py
@@ -448,9 +448,10 @@ class trainer(object):
             for name, loss in running_loss.items():
                 loss = np.mean(loss)
                 pbar.write("avg loss {}: {}".format(name, loss))
+                neptune.log_metric(f"eval_avg_{name}_loss", loss)
 
             # Log to cloud experiment tracker
-            neptune.log_metric(f"{name}_loss", loss)
+            neptune.log_metric(f"eval_{name}_loss", loss)
 
             self.writer.add_scalar('eval/{}_loss'.format(name),
                                     loss,
@@ -458,6 +459,9 @@ class trainer(object):
         else:
             self.valid_losses['epoch'] = epoch
             self.valid_losses['losses'] = running_loss
+
+            # Log to cloud experiment tracker
+            neptune.log_metric(f"valid_running_loss", running_loss)
 
             with open(os.path.join(self.save_path, 'valid_losses.pkl'), "wb") as f:
                 pbar.write("saved log to {}".format(os.path.join(self.save_path, 'valid_losses.pkl')))

--- a/pase/models/WorkerScheduler/trainer.py
+++ b/pase/models/WorkerScheduler/trainer.py
@@ -390,7 +390,8 @@ class trainer(object):
         pbar.write("=" * 50)
         pbar.write('Batch {}/{} (Epoch {}) step: {}:'.format(bidx, self.bpe, epoch, step))
 
-        neptune.log_text('Batch {}/{} (Epoch {}) step: {}:'.format(bidx, self.bpe, epoch, step))
+        neptune.log_text('progress', 'Batch {}/{} (Epoch {}) step: {}:'.format(bidx, self.bpe, epoch, step))
+        neptune.log_metric('epoch', epoch)
 
         for lr in lrs.keys():
             neptune.log_metric(f"learning_rate_{lr}", lrs[lr])

--- a/pase/transforms.py
+++ b/pase/transforms.py
@@ -1,4 +1,5 @@
 import torch
+import torchaudio
 import torch.nn.functional as F
 import tqdm
 import gammatone
@@ -972,7 +973,7 @@ class Prosody(object):
             zcr = torch.tensor(zcr.astype(np.float32))
             zcr = zcr[:, :max_frames]
             # finally obtain energy
-            egy = librosa.feature.rmse(y=wav, frame_length=self.win,
+            egy = librosa.feature.rms(y=wav, frame_length=self.win,
                                        hop_length=self.hop,
                                        pad_mode='constant')
             egy = torch.tensor(egy.astype(np.float32))
@@ -1611,7 +1612,8 @@ class SimpleAdditive(object):
         if hasattr(self, 'cache') and filename in self.cache:
             return self.cache[filename]
         else:
-            nwav, rate = sf.read(filename)
+            nwav, rate = torchaudio.load(filename)
+            nwav = nwav.numpy().squeeze()
             if hasattr(self, 'cache'):
                 self.cache[filename] = nwav
         return nwav

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ tensorboardX==1.6
 webrtcvad==2.0.10
 cupy-cuda101
 pynvrtc==8.0 
+neptune-client==0.4.92
 git+https://github.com/salesforce/pytorch-qrnn
 git+https://github.com/detly/gammatone
 git+https://github.com/pswietojanski/kaldi-io-for-python.git

--- a/train.py
+++ b/train.py
@@ -331,6 +331,8 @@ def train(opts):
     model_description = str(Trainer.model)
     tfh = tempfile.NamedTemporaryFile(mode="w")
     tfh.write(model_description)
+    tfh.flush()
+
     print(model_description)
     num_params = Trainer.model.frontend.describe_params()
     print(f'Frontend params: {num_params}')


### PR DESCRIPTION
Addressing the gap found by @MittalShruti.  The python packaged version of pycodec2 can't find the required numpy headers on its own, complicating installation. I've forked the pycodec2 repo, fixed the issue and created a pull request, but until that gets approved/merged/included in the build, the easiest way to get pycodec2 might be to build from source.  I'm actually working on dockerizing PASE+ training at the moment, so a nice clean pycodec2 install helps me there too.